### PR TITLE
NetSync continue fetching headers from peer

### DIFF
--- a/deps/CoinQ/src/CoinQ_netsync.cpp
+++ b/deps/CoinQ/src/CoinQ_netsync.cpp
@@ -190,12 +190,15 @@ NetworkSync::NetworkSync(const CoinQ::CoinParams& coinParams, bool bCheckProofOf
 
                 vector<uchar_vector> locatorHashes = m_blockTree.getLocatorHashes(1);
                 if (locatorHashes.empty()) throw runtime_error("Blocktree is empty.");
-                if (headersMessage.headers[headersMessage.headers.size() - 1].hash() != locatorHashes[0])
+                uchar_vector peerBranchTipHash = headersMessage.headers[headersMessage.headers.size() - 1].hash();
+                if (peerBranchTipHash != locatorHashes[0])
                 {
-                    throw runtime_error("Blocktree conflicts with peer.");
+                    // peer's best chain is different than ours, we will continue to fetch headers
+                    // at some point if their chain is heavier it will be reflected in the blocktree
+                    LOGGER(trace) << "Processed headers did not form a new best chain." << std::endl;
                 }
  
-                peer.getHeaders(locatorHashes);
+                peer.getHeaders({peerBranchTipHash});
             }
             else
             {


### PR DESCRIPTION
When a significantly large reorg occurs on testnet3 while netsync has been offline for a significant time, we sometimes reach a situation where after processing headers from a peer during header sync, the headers do not form a new best chain as far as we can tell from our blocktree. This causes the runtime error ""Blocktree conflicts with peer." to be thrown, and no further headers are fetched.

There are several possibilities that could be causing this scenario to occur, that might be worth discussing, but in all cases this is a small patch, that forces netsync to continue fetching headers from the peer, which might eventually become the best chain and complete a successful header sync.
